### PR TITLE
Edit renamenodes.sh to have updated node names show up correctly in newer versions of OpsCenter

### DIFF
--- a/src/bin/renamenodes.sh
+++ b/src/bin/renamenodes.sh
@@ -7,33 +7,68 @@ function usage() {
    echo "Usage: renamenodes.sh <node name stem>"
 }
 
-STEM=$1
+if [[ -z $1 ]]; then
+    usage
+    exit
+fi
+
+# Read from the workstation's /etc/hosts, find IPs that have a node#
+CLUSTER=$1
+NEWHOST=""
+NODELIST=""
+declare -a NODENAME
+re="^(([0-9]{1,3}.){3}[0-9]{1,3})((.*)node([0-9]+)$)"
+i=0
+while IFS='' read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ $re ]]; then
+      if [ -z "$NEWHOST" ]; then
+        NEWHOST="${BASH_REMATCH[1]} $CLUSTER${BASH_REMATCH[5]}${BASH_REMATCH[3]}"
+        NODELIST="${BASH_REMATCH[1]}"
+      else
+        NEWHOST="$NEWHOST\n${BASH_REMATCH[1]} $CLUSTER${BASH_REMATCH[5]}${BASH_REMATCH[3]}"
+        NODELIST="$NODELIST ${BASH_REMATCH[1]}"
+      fi
+      NODENAME[$i]="$CLUSTER${BASH_REMATCH[5]}"
+      i=$((i+1))
+    else 
+      if [ -z "$NEWHOST" ]; then
+        NEWHOST="$line"
+      else
+        NEWHOST="$NEWHOST\n$line"
+      fi 
+    fi
+done < /etc/hosts
+
+echo -e $NEWHOST > /etc/hosts
+echo $NODELIST
 
 echo Stopping services:
 
-NODELIST="0 1 2"
-
-for i in $NODELIST ; do
-   ssh node$i bash -c "'sudo service datastax-agent stop; sudo service dse stop 2>$LOG; sudo service cassandra stop 2>$LOG; sudo service opscenterd stop 2>$LOG'"
+for ip in $NODELIST ; do
+   echo ${ip}:
+   ssh $ip bash -c "'sudo service datastax-agent stop; sudo service dse stop 2>$LOG; sudo service cassandra stop 2>$LOG; sudo service opscenterd stop 2>$LOG'"
 done
 echo
 
 echo Renaming hosts:
-for i in $NODELIST; do
-  ssh node$i  hostname $STEM$i
-  ssh node$i sed -i "'s/node$i/$STEM$i/'" /etc/hosts
+i=0
+for ip in $NODELIST; do
+  echo $ip
+  scp /etc/hosts root@$ip:/etc/hosts
+  ssh $ip 'newhost='${NODENAME[$i]}'; echo $newhost;  sudo bash -c '"'"'echo `curl -s http://169.254.169.254/latest/meta-data/local-ipv4` '"'"'$newhost'"'"' >> /etc/hosts'"'"'; sudo hostname $newhost;' ;
+i=$((i+1))
 done
 echo
 
 echo Starting services:
-for i in $NODELIST ; do
-   ssh node$i sudo service opscenterd start 2>$LOG
+for ip in $NODELIST ; do
+  echo $ip
+   ssh $ip sudo service opscenterd start 2>$LOG
 done
 
-for i in $NODELIST ; do
-   ssh node$i bash -c "'sudo service cassandra start 2>$LOG; sudo service dse start 2>$LOG; sleep 5; sudo service datastax-agent start'"
+for ip in $NODELIST ; do
+   echo $ip
+   ssh $ip bash -c "'sudo service cassandra start 2>$LOG; sudo service dse start 2>$LOG; sleep 5; sudo service datastax-agent start'"
 done
 
 sleep 20
-
-cluster2hosts.sh node0


### PR DESCRIPTION
One issue that was reported recently was that the node name does not get updated in OpsCenter after running the renamenodes.sh script. Previous behavior seems to indicate that OpsCenter determines a node's name based on it's hostname, which the previous script changes. Newer version of OpsCenter now seems to select a node's name based on the /etc/hosts file.

I've made some changes to fulfill two purposes:
1. Change how the nodes get renamed. There seems to have been some reliability issues with using nodetool status to get a list of the nodes. Instead, using an extremely important assumption that all Cassandra nodes in the cluster are found in the /etc/hosts on the workstation
2. I check for IPs that have an alias with the pattern `node#` and then add a new alias in the front using the provided stem name. Rather than having to do that on all the nodes, the script makes the change on the workstation, and them copies it to the rest of the nodes. This solves the issue of making sure OpsCenter picks up the correct node name.
